### PR TITLE
Alternative links for downloading IEEE LaTeX template

### DIFF
--- a/cfp/formatting-instructions.html
+++ b/cfp/formatting-instructions.html
@@ -24,6 +24,7 @@
           <p class="text-justify">
             Papers must strictly adhere to the two-column IEEE conference proceedings format.
             Please use the available <a href="http://www.ieee.org/conferences_events/conferences/publishing/templates.html">Manuscript Templates for Conference Proceedings</a>.
+            <br/>* If the link provided above is broken, please use <a href="https://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran">CTAN direct link</a>. 
           </p>
 
           <h3>LaTeX Users</h3>


### PR DESCRIPTION
IEEE link for LaTeX is currently (BRT 19:00) broken at page  https://www.ieee.org/conferences/publishing/templates.html => https://www.ieee.org/content/dam/ieee-org/ieee/web/org/pubs/936414.zip
The Word A4 template is not.
An alternative (and direct link ctan link) is given at: https://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/